### PR TITLE
Updated readme and dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are currently interaction classes for the following DBs and Apps:
 
 ## Development
 
-#### Getting Started
+### Getting Started
 
 It is recommended to use the steps below to set up a virtual environment for development:
 
@@ -19,12 +19,12 @@ It is recommended to use the steps below to set up a virtual environment for dev
 ```
 python3 -m venv <virtual env name>
 source venv/bin/activate
-pip install -r requirements.txt --process-dependency-links
+pip install -r requirements-dev.txt
 ```
 
 prepare `etl.cfg` at the root folder using key and values from `tests/test_data/db.test.cfg`
 
-#### Testing
+### Testing
 prepare db.test.cfg at the root folder using key and values from `tests/test_data/db.test.cfg`
 
 Run

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2==2.7.1
+psycopg2>=2.8
 cocore==1.2.0
 cocloud==0.2
 python-tds==1.9.1

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ setup(
   download_url='https://github.com/equinoxfitness/datacoco.db/archive/v-1.0.tar.gz',
   keywords=['helper', 'common', 'db', 'api'],   # Keywords that define your package best
   install_requires=[
-    'psycopg2==2.7.7',
+    'psycopg2>=2.8',
     'python-tds==1.9.1',
     'salesforce-bulk==2.1.0',
     'simple-salesforce==0.72.2',
     'salesforce-oauth-request==1.0.6',
     'simplejson==3.14.0',
-    'sqlalchemy==1.2.7',
+    'sqlalchemy==1.3.0b1',
     'redis==2.10.6',
     'PyMySQL==0.9.3',
   ]


### PR DESCRIPTION
Updated requirement psycopg2 to 2.8 and sqlalchemy to 1.3.0b1 to remove warnings.
Fixed install directions in README because `--process-dependency-links` is not supported anymore.